### PR TITLE
GH #25:  Enable AWS image for EC2 Instance Connect

### DIFF
--- a/scripts/aws/xlt-home/post-setup.sh
+++ b/scripts/aws/xlt-home/post-setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# Update package index and install 'EC2 Instance Connect' package
+DEBIAN_FRONTEND=noninteractive apt-get update && \
+  apt-get --no-install-recommends -y install ec2-instance-connect
+

--- a/scripts/common/xlt-home/setup-image.sh
+++ b/scripts/common/xlt-home/setup-image.sh
@@ -303,7 +303,7 @@ fi
 # Execute post-installation script if present and executable
 if [ -x "$SCRIPT_DIR/post-setup.sh" ]; then
   echo "Running post-setup"
-  exec "$SCRIPT_DIR/post-setup.sh"
+  "$SCRIPT_DIR/post-setup.sh"
   if [ $? != 0 ]; then exit 4; fi
 fi
 

--- a/scripts/common/xlt-home/setup-image.sh
+++ b/scripts/common/xlt-home/setup-image.sh
@@ -300,6 +300,13 @@ if [ -d /root/.ssh ]; then
   if [ $? != 0 ]; then exit 4; fi
 fi
 
+# Execute post-installation script if present and executable
+if [ -x "$SCRIPT_DIR/post-setup.sh" ]; then
+  echo "Running post-setup"
+  exec "$SCRIPT_DIR/post-setup.sh"
+  if [ $? != 0 ]; then exit 4; fi
+fi
+
 
 ## clean up
 echo "Clean up setup files"


### PR DESCRIPTION
Fixes #25 

Changes:
- added post-installation script to install 'EC2 Instance Connect' package (AWS only)